### PR TITLE
fix server.py path in the colab demo

### DIFF
--- a/examples/OmniParse_GoogleColab.ipynb
+++ b/examples/OmniParse_GoogleColab.ipynb
@@ -183,7 +183,7 @@
         "\n",
         "threading.Thread(target=iframe_thread, daemon=True, args=(8000,)).start()\n",
         "\n",
-        "!python server.py --host 127.0.0.1 --port 8000 --documents --media --web"
+        "!python omniparse/server.py --host 127.0.0.1 --port 8000 --documents --media --web"
       ]
     },
     {


### PR DESCRIPTION
fixed the file path of server.py which was causing an issue in the colab demo
<img width="720" alt="Screenshot 2024-06-28 at 11 09 39 AM" src="https://github.com/adithya-s-k/omniparse/assets/63744278/0b3c67a0-045c-44df-8ea7-d0f6c904bbff">
