### PR TITLE
Fix ambiguity in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ cd omniparse
 Create a Virtual Environment:
 
 ```bash
-conda create --n omniparse-venv python=3.10
+conda create --name omniparse-venv python=3.10
 conda activate omniparse-venv
 ```
 


### PR DESCRIPTION
I am not sure since when, but modern versions of Conda treat `--n` as an ambiguity between a few possible arguments, this should ease installation for new users.