### PR TITLE
Fix marker-pdf version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ flash-attn = "^2.5.9"
 art = "^6.2"
 gradio = "^4.37.1"
 nltk = "^3.8.1"
-marker-pdf = "^0.2.15"
+marker-pdf = "^0.2.16"
 
 [tool.poetry.scripts]
 omniparse = "server:main"


### PR DESCRIPTION
Bump marker-pdf version to accommodate for the changes in surya-models. 
The changes break download.py and upgrading to 0.2.16 solves the issue.
See changes [here](https://github.com/VikParuchuri/marker/pull/229/files#diff-07521f2e4d8e654778fb293b64ebae525c92042854c24421fa1b123f2555644fR6)